### PR TITLE
refactored lib_wahoo_install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -264,7 +264,7 @@ lib_wahoo_install() {
   test -z ${HOST+_} && HOST="github.com"
   test -z ${REPO+_} && REPO="fish-shell/wahoo"
   test -z ${BRANCH+_} && BRANCH="master"
-  URL="${PROTOCOL}://${HOST}/${REPO}.git"
+  local URL="${PROTOCOL}://${HOST}/${REPO}.git"
 
   util_log INFO "Cloning Wahoo → ${URL}"
 
@@ -275,7 +275,7 @@ lib_wahoo_install() {
   fi
 
   pushd ${BASE}/.wahoo >/dev/null 2>&1
-  REF=$(git config remote.upstream.url)
+  local REF=$(git config remote.upstream.url)
   if [ -z "${REF}" ]; then
     git remote add upstream $URL
   else
@@ -297,8 +297,8 @@ lib_wahoo_install() {
 
   util_log INFO "Adding Wahoo bootstrap → ${FISH_CONFIG}/config.fish"
 
-  FISH_CONFIG_FILE="${FISH_CONFIG}/config.fish"
-  WAHOO_CONFIG="${HOME}/.config/wahoo"
+  local FISH_CONFIG_FILE="${FISH_CONFIG}/config.fish"
+  local WAHOO_CONFIG="${HOME}/.config/wahoo"
   test -z ${CUSTOM+_} && CUSTOM="${BASE}/.dotfiles"
   echo "set -g WAHOO_PATH $(echo "${BASE}/.wahoo" \
   | sed -e "s|$HOME|\$HOME|")" > ${FISH_CONFIG_FILE}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,11 +106,11 @@ util_log() {
 }
 
 util_log_default_success() {
-  util_log INFO "$1 successfully installed."
+  util_log INFO "$1 successfully installed"
 }
 
 util_log_default_error() {
-  util_log ERROR "You need admin permissions to continue."
+  util_log ERROR "You need admin permissions to continue"
 }
 
 util_display_success_msg() {
@@ -173,11 +173,11 @@ lib_fish_install() {
   }
 
   if ! util_env_can git; then
-    util_log INFO "Installing git..."
+    util_log INFO "Installing 'git'"
     if lib_git_install; then
       util_log_default_success "git"
     else
-      util_log ERROR "You need admin permissions to install git"
+      util_log ERROR "You need admin permissions to install 'git'"
       exit 1
     fi
   fi
@@ -193,13 +193,13 @@ lib_fish_install() {
         exit 1
       fi
     else
-      util_log ERROR "You need Homebrew or Xcode tools."
-      util_log INFO "For Xcode try: xcode-select --install"
+      util_log ERROR "You need 'Homebrew' or 'Xcode' commandline tools"
+      util_log INFO "For Xcode try: 'xcode-select --install'"
       exit 1
     fi
   else
     if ! util_env_can "autoconf"; then
-      util_log INFO "Installing autoconf..."
+      util_log INFO "Installing 'autoconf'"
       if lib_autoconf_install; then
         util_log_default_success "autoconf"
       else
@@ -254,8 +254,7 @@ lib_wahoo_install() {
   util_log INFO "Resolving Wahoo path → ${BASE}/.wahoo"
 
   if [ -d "${BASE}/.wahoo" ]; then
-    util_log ERROR "Wahoo is already installed."
-    util_log INFO "If you would like to update Wahoo please call \"fish -c 'wa update\"."
+    util_log WARN "Existing installation detected, aborting"
     exit 1
   fi
 
@@ -271,7 +270,7 @@ lib_wahoo_install() {
 
   if ! git clone -q --depth 1 -b "${BRANCH}" "${URL}" "${BASE}/.wahoo"; then
     util_log ERROR "Could not clone the repository → ${BASE}/.wahoo:${BRANCH}"
-    util_log INFO "Please check your environment (git installed?) and try again."
+    util_log INFO "Please check your environment ('git' installed?) and try again"
     exit 1
   fi
 
@@ -288,7 +287,7 @@ lib_wahoo_install() {
 
   test -z ${FISH_CONFIG+_} && FISH_CONFIG="${HOME}/.config/fish"
   if [ -e "${FISH_CONFIG}/config.fish" ]; then
-    util_log INFO "Found existing fish configuration → ${FISH_CONFIG}/config.fish"
+    util_log INFO "Found existing 'fish' configuration → ${FISH_CONFIG}/config.fish"
     util_log WARN "Writing back-up copy → ${FISH_CONFIG}/config.copy"
     cp "${FISH_CONFIG}/config.fish" "${FISH_CONFIG}/config.copy"
   else
@@ -316,12 +315,12 @@ lib_wahoo_install() {
 
 lib_main_run() {
   util_log TITLE "== Bootstraping Wahoo =="
-  util_log INFO "Installing dependencies..."
+  util_log INFO "Installing dependencies"
 
   if ! util_env_can "fish"; then
-    util_log INFO  "Installing fish..."
+    util_log INFO  "Installing fish"
     if lib_fish_install; then
-      util_log WARN "Setting fish as your default shell."
+      util_log INFO "Setting 'fish' as your default shell"
       lib_fish_set_as_default_shell
     fi
   fi
@@ -336,7 +335,7 @@ lib_main_run() {
       util_env_swap_process "fish"
     fi
   else
-    util_log ERROR "Alas, Wahoo failed to install correctly."
+    util_log ERROR "Alas, Wahoo failed to install correctly"
     util_log INFO "Please complain here → git.io/wahoo-issues"
     exit 1
   fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -264,23 +264,25 @@ lib_wahoo_install() {
   test -z ${HOST+_} && HOST="github.com"
   test -z ${REPO+_} && REPO="fish-shell/wahoo"
   test -z ${BRANCH+_} && BRANCH="master"
-  local URL="${PROTOCOL}://${HOST}/${REPO}.git"
+  local GIT_URL="${PROTOCOL}://${HOST}/${REPO}.git"
 
-  util_log INFO "Cloning Wahoo → ${URL}"
-
-  if ! git clone -q --depth 1 -b "${BRANCH}" "${URL}" "${BASE}/.wahoo"; then
+  util_log INFO "Cloning Wahoo → ${GIT_URL}"
+  if ! git clone -q --depth 1 -b "${BRANCH}" "${GIT_URL}" "${BASE}/.wahoo"; then
     util_log ERROR "Could not clone the repository → ${BASE}/.wahoo:${BRANCH}"
     util_log INFO "Please check your environment ('git' installed?) and try again"
     exit 1
   fi
 
   pushd ${BASE}/.wahoo >/dev/null 2>&1
-  local REF=$(git config remote.upstream.url)
-  if [ -z "${REF}" ]; then
-    git remote add upstream $URL
+  local GIT_REV=$(git rev-parse HEAD) >/dev/null 2>&1
+  local GIT_UPSTREAM=$(git config remote.upstream.url)
+  if [ -z "${GIT_UPSTREAM}" ]; then
+    git remote add upstream ${GIT_URL}
   else
-    git remote set-url upstream $URL
+    git remote set-url upstream ${GIT_URL}
   fi
+  util_log INFO "Wahoo revision id → ${GIT_REV}"
+  echo ${GIT_REV} > "${WAHOO_CONFIG}/revision"
   popd >/dev/null 2>&1
 
   ## CONFIGURATION ##

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -318,7 +318,7 @@ lib_main_run() {
   util_log INFO "Installing dependencies"
 
   if ! util_env_can "fish"; then
-    util_log INFO  "Installing fish"
+    util_log INFO  "Installing 'fish'"
     if lib_fish_install; then
       util_log INFO "Setting 'fish' as your default shell"
       lib_fish_set_as_default_shell

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -282,7 +282,6 @@ lib_wahoo_install() {
     git remote set-url upstream ${GIT_URL}
   fi
   util_log INFO "Wahoo revision id → ${GIT_REV}"
-  echo ${GIT_REV} > "${WAHOO_CONFIG}/revision"
   popd >/dev/null 2>&1
 
   ## CONFIGURATION ##
@@ -312,6 +311,7 @@ lib_wahoo_install() {
     util_log INFO "Writing Wahoo configuration → ${WAHOO_CONFIG}"
     mkdir -p "${WAHOO_CONFIG}"
     test -f "${WAHOO_CONFIG}/theme" || echo default > "${WAHOO_CONFIG}/theme"
+    test -f "${WAHOO_CONFIG}/revision" || echo ${GIT_REV} > "${WAHOO_CONFIG}/revision"
   fi
 }
 


### PR DESCRIPTION
use depth of 1 for all 'git clone' operations
refactored `lib_wahoo_install`:
* removed 'forking' part
* smoothly set remote 'upstream'
* save some LOC (`sh` has POSIX-like `&&` :cat:)
* lower logging level for configuration writes but keep a warning on writing back-up copy
* removed `INIT` (only used once)
* introduced `FISH_CONFIG_FILE`
* unified logging style
* minor move-arounds