### PR TITLE
fix/improve travis legacy builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_script:
   - tree -h
 script: /bin/sh bootstrap.sh
 after_script:
-  - echo revision: $(cat ~/.config/wahoo/revision)
+  - echo revision : $(cat ~/.config/wahoo/revision)
+  - echo theme    : $(cat ~/.config/wahoo/theme)
   - cd ~/.config/fish; tree -h
   - cd ~/.config/wahoo; tree -h
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ after_script:
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/281fd475b5a3cedd8f5d
+      - https://webhooks.gitter.im/e/88afd36810236434b92e
     on_success: change  # options: [always|never|change] default: always
     on_failure: change  # options: [always|never|change] default: always
     on_start: false     # default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 language: c
 os:
   - linux
-#  - osx # currently not supported
-sudo: false
+  - osx # currently not supported therefore status unknow ..
+matrix:
+  allow_failures:
+    - os: osx # .. so allow it to fail for now
+sudo: true # legacy travis infra, because we currently need sudo to install fish
 addons:
   apt:
     packages:
     - tree
-    - fish
-before_script: pwd; tree -h
+cache:
+  directories:
+  - src
+before_script:
+  - echo "build-no: ${TRAVIS_BUILD_NUMBER}\nrepo: ${TRAVIS_REPO_SLUG}\nbranch: ${TRAVIS_BRANCH}\ncommit: ${TRAVIS_COMMIT}\npull-request: ${TRAVIS_PULL_REQUEST}"
+  - pwd; tree -h
 script: /bin/sh bootstrap.sh
 after_script:
-  - cd ~/.config/fish; tree -h; find . -type f | xargs cat
-  - cd ~/.config/wahoo; tree -h; find . -type f | xargs cat
+  - echo revision: $(cat ~/.config/wahoo/revision)
+  - cd ~/.config/fish; tree -h
+  - cd ~/.config/wahoo; tree -h
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,22 @@
 language: c
-
 os:
   - linux
-  - osx # currently not supported
-
+#  - osx # currently not supported
 sudo: false
-
 addons:
- apt:
-   packages:
-   - fish
-
-before_install:
-  - curl -L git.io/wa | sh
-
-script:
-  - echo "The Fishshell Framework"
-
+  apt:
+    packages:
+    - tree
+    - fish
+before_script: pwd; tree -h
+script: /bin/sh bootstrap.sh
+after_script:
+  - cd ~/.config/fish; tree -h; find . -type f | xargs cat
+  - cd ~/.config/wahoo; tree -h; find . -type f | xargs cat
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/88afd36810236434b92e
+      - https://webhooks.gitter.im/e/281fd475b5a3cedd8f5d
     on_success: change  # options: [always|never|change] default: always
     on_failure: change  # options: [always|never|change] default: always
     on_start: false     # default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   - src
 before_script:
   - echo "build-no: ${TRAVIS_BUILD_NUMBER}\nrepo: ${TRAVIS_REPO_SLUG}\nbranch: ${TRAVIS_BRANCH}\ncommit: ${TRAVIS_COMMIT}\npull-request: ${TRAVIS_PULL_REQUEST}"
-  - pwd; tree -h
+  - tree -h
 script: /bin/sh bootstrap.sh
 after_script:
   - echo revision: $(cat ~/.config/wahoo/revision)


### PR DESCRIPTION
* stay in legacy infra but use bootstrap.sh to build, not the curl-call
* will build on osx when travis re-enables it, but failure is allowed in the meantime
* cache src directory to speedup builds
* revamp diagnostic output